### PR TITLE
fix: 배경색 생성 스크립트가 이로치 스프라이트를 샘플링하던 버그 수정

### DIFF
--- a/scripts/helpers/get_pokemon_background_color.py
+++ b/scripts/helpers/get_pokemon_background_color.py
@@ -49,11 +49,19 @@ def main():
     base_path = pathlib.Path("./imgs/sprites/pokemon")
     colors = {}
 
-    for sprite_path in base_path.iterdir():
+    for sprite_path in sorted(base_path.iterdir()):
         if not ("front" in sprite_path.name and sprite_path.name.endswith("1.png")):
             continue
 
+        if "shiny" in sprite_path.name:
+            continue
+
         id = int(sprite_path.name.split("_")[0])
+
+        exact = base_path / f"{id}_front_1.png"
+        if exact.exists() and sprite_path.name != exact.name:
+            continue
+
         if id in colors:
             continue
 


### PR DESCRIPTION
배경색 생성 스크립트의 매칭 조건(\`"front" in name\`)이 \`front_shiny_1.png\`(이로치)도 매칭해, 디렉토리 순회 순서에 따라 이로치 팔레트의 평균이 저장되던 버그를 수정합니다.

- 이로치 스프라이트 제외, 비이로치 \`{id}_front_1.png\` 우선
- \`sorted()\` 순회로 결과 결정적(deterministic)으로

이 버그로 프론트엔드 \`pokemonBackgroundColors\` 493개 중 222개가 이로치 색으로 오염되어 있었습니다 (예: 마자용 → 이로치 핑크). 프론트 상수 재생성은 gitpokecol/frontend#20 에서 처리했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)